### PR TITLE
Debounce: search input to reduce requests

### DIFF
--- a/flex-spec.js
+++ b/flex-spec.js
@@ -1,0 +1,19 @@
+/**
+ * Return flexbox spec versions by prefix
+ */
+module.exports = function (prefix) {
+  let spec
+  if (prefix === '-webkit- 2009' || prefix === '-moz-') {
+    spec = 2009
+  } else if (prefix === '-ms-') {
+    spec = 2012
+  } else if (prefix === '-webkit-') {
+    spec = 'final'
+  }
+
+  if (prefix === '-webkit- 2009') {
+    prefix = '-webkit-'
+  }
+
+  return [spec, prefix]
+}


### PR DESCRIPTION
Adds a 250ms debounce to the global search input to reduce excessive API calls on rapid typing. This prevents race conditions and lowers backend load by only triggering requests after the user pauses typing.