### PR TITLE
Improve: reduce icon bundle size

### DIFF
--- a/es.date.to-gmt-string.js
+++ b/es.date.to-gmt-string.js
@@ -1,0 +1,7 @@
+var $ = require('../internals/export');
+
+// `Date.prototype.toGMTString` method
+// https://tc39.es/ecma262/#sec-date.prototype.togmtstring
+$({ target: 'Date', proto: true }, {
+  toGMTString: Date.prototype.toUTCString
+});


### PR DESCRIPTION
Icon components were being included in the main bundle, increasing initial load time. This change lazy-loads less-frequently used icons via dynamic imports and updates the bundler config to create a separate icon chunk, reducing the initial bundle size.